### PR TITLE
feat: create and link reusable layout and head component with SEO integration for title and description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "astro-portfolio",
       "version": "0.0.1",
       "dependencies": {
-        "astro": "^2.5.6"
+        "astro": "^2.5.6",
+        "astro-seo": "^0.7.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1220,6 +1221,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/astro-seo": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/astro-seo/-/astro-seo-0.7.4.tgz",
+      "integrity": "sha512-E+wJmxOnvBRjgzVctdGk/VdwoEqeQ6Q/KgVW2wRBXZWJVDgOweB32Da/UiH0/FpGncPzo2daOrc08DNn5wTanw=="
     },
     "node_modules/bail": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.5.6"
+    "astro": "^2.5.6",
+    "astro-seo": "^0.7.4"
   }
 }

--- a/src/layouts/MainHead.astro
+++ b/src/layouts/MainHead.astro
@@ -1,0 +1,18 @@
+---
+import { SEO } from 'astro-seo';
+const { title, seoTitle, seoDesc } = Astro.props;
+---
+
+<head>
+  <SEO title={seoTitle} description={seoDesc} />
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{title}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Carlito:wght@400;700&display=swap"
+    rel="stylesheet"
+  />
+</head>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -1,0 +1,17 @@
+---
+import MainHead from './MainHead.astro';
+const { title, seoTitle, seoDesc } = Astro.props;
+---
+
+<html>
+  <MainHead title={title} seoTitle={seoTitle} seoDesc={seoDesc} />
+  <body>
+    <slot />
+    <style>
+      body {
+        font-family: 'Carlito', sans-serif;
+        min-height: 100vh;
+      }
+    </style>
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,15 +1,11 @@
 ---
+import MainLayout from '../layouts/MainLayout.astro';
 ---
 
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Astro</title>
-	</head>
-	<body>
-		<h1>Astro</h1>
-	</body>
-</html>
+<MainLayout
+  title="John Portfolio Site"
+  seoTitle="John Does, Software Engineer Portfolio"
+  seoDesc="Software Engineer who expertise in Astro, React, NextJS and Node"
+>
+  slot: Index Page
+</MainLayout>


### PR DESCRIPTION
Dependency added : [astro-seo](https://github.com/jonasmerlin/astro-seo)

Components added: 

1. MainHead ( includes title and description attributes, imported [Carlito Font](https://fonts.google.com/specimen/Carlito?query=carlito) )
2. MainLayout ( includes MainHead component, with a slot tag )

Changes: index.astro ( root url for website now uses MainLayout component to display information on browser )